### PR TITLE
Fix to slicekit flash muxing for v13 tools

### DIFF
--- a/module_slicekit_support/src/SLICEKIT-L16/slicekit_init.S
+++ b/module_slicekit_support/src/SLICEKIT-L16/slicekit_init.S
@@ -15,7 +15,14 @@
 __slicekit_init:
   // Only run this on tile[0]
   bl get_local_tile_id
-  bt r0, .Lskip
+  mov r4, r0
+  ldaw r11, cp[tile]
+  ldc r0, 0
+  ld16s r0, r11[r0]
+  zext r0, 16
+  bl get_tile_id
+  eq r0, r0, r4
+  bf r0, .Lskip
 
 __slicekit_init_handle_flash:
   // Enable the clock and port required for doing the output

--- a/module_slicekit_support/src/SLICEKIT-L2/slicekit_init.S
+++ b/module_slicekit_support/src/SLICEKIT-L2/slicekit_init.S
@@ -15,7 +15,14 @@
 __slicekit_init:
   // Only run this on tile[0]
   bl get_local_tile_id
-  bt r0, .Lskip
+  mov r4, r0
+  ldaw r11, cp[tile]
+  ldc r0, 0
+  ld16s r0, r11[r0]
+  zext r0, 16
+  bl get_tile_id
+  eq r0, r0, r4
+  bf r0, .Lskip
 
 __slicekit_init_handle_flash:
   // Enable the clock and port required for doing the output


### PR DESCRIPTION
Due to a mapper change in v13, the tile id is no longer 0 when XScope is
enabled. This meant that the flash pin muxing on the slicekit core board was not
being correctly disabled.

This patch now does the correct thing and gets the tile id of
tile 0 and compares it to the current tile id.
