### PR TITLE
Remove .core/.corerev

### DIFF
--- a/module_locks/src/swlock_asm.S
+++ b/module_locks/src/swlock_asm.S
@@ -33,5 +33,3 @@ swlock_try_acquire:
 .set swlock_try_acquire.maxchanends, 0
 .set swlock_try_acquire.maxtimers, 0
 .set swlock_try_acquire.maxthreads, 1
-          .core     "XS1"
-          .corerev  "REVB"


### PR DESCRIPTION
Remove .core/.corerev in order to make usable on xCORE-200 (note: this matches the new lib_locks)